### PR TITLE
Add addition date formats

### DIFF
--- a/lib_formatting.php
+++ b/lib_formatting.php
@@ -1316,7 +1316,9 @@ function toDateTime($str,$seconds=false) {
 		return "";
 	}
 	// have different languages here
-	return $result[3].".".$result[2].".".$result[1].", ".$result[4].":".$result[5].($seconds?":".$result[6]:"");
+	return $result[3].".".$result[2].".".$result[1].", ".$result[4].":".$result[5].($seconds?":".$result[6]:"");   // Khoi's note: German style
+    // return $result[2]."/".$result[3]."/".$result[1].", ".$result[4].":".$result[5].($seconds?":".$result[6]:"");   // Khoi's note: American style mm/dd/yyyy
+    // return $result[1]."-".$result[2]."-".$result[3].", ".$result[4].":".$result[5].($seconds?":".$result[6]:"");   // Khoi's note: yyyy-mm-dd style
 }
 
 function toDate($str) {
@@ -1329,7 +1331,8 @@ function toDate($str) {
 		return "";
 	}
 	// have different languages here
-	return $result[3].".".$result[2].".".$result[1].$result[4];
+	return $result[3].".".$result[2].".".$result[1].$result[4];   // Khoi's note: German style
+    // return $result[1]."-".$result[2]."-".$result[3].$result[4];    // Khoi's note: yyyy-mm-dd style
 }
 
 function getSQLDate($str) {
@@ -1337,13 +1340,21 @@ function getSQLDate($str) {
 	if (empty($str)) {
 		return fixStr(invalidSQLDate);
 	}
-	if (!preg_match("/^(\d+)\.(\d+)\.(\d{2,4})/",$str,$result)) {
-		return fixStr(invalidSQLDate);
+	// Khoi: match for German date (dd.mm.yy)
+	if (preg_match("/^(\d+)\.(\d+)\.(\d{2,4})/",$str,$result)) {
+		$result[3]=fixYear($result[3]);
+		fillZero($result[1]);
+		fillZero($result[2]);
+		return fixStr($result[3]."-".$result[2]."-".$result[1]);
 	}
-	$result[3]=fixYear($result[3]);
-	fillZero($result[1]);
-	fillZero($result[2]);
-	return fixStr($result[3]."-".$result[2]."-".$result[1]);
+	// Khoi: match for American Date (mm-dd-yy or mm/dd/yy or mm-dd-yyyy or mm/dd/yyyy)
+	else if (preg_match("/^(\d+)[\/-](\d+)[\/-](\d{2,4})/",$str,$result)) {
+		$result[3]=fixYear($result[3]);
+		fillZero($result[1]);
+		fillZero($result[2]);
+		return fixStr($result[3]."-".$result[1]."-".$result[2]);
+	}
+	return fixStr(invalidSQLDate);
 }
 
 function fillZero(& $number,$digits=2) {
@@ -1396,6 +1407,26 @@ function getGermanDate($timestamp=null,$alsoTime=false) {
 	return date("d.m.Y",$timestamp);
 }
 
+function getAmericanDate($timestamp=null,$alsoTime=false) {
+	if (is_null($timestamp)) {
+		$timestamp=time();
+	}
+	if ($alsoTime) {
+		return date("m/d/Y H:i:s",$timestamp);
+	}
+	return date("m/d/Y",$timestamp);
+}
+
+function getPrettyDate($timestamp=null,$alsoTime=false) {
+	if (is_null($timestamp)) {
+		$timestamp=time();
+	}
+	if ($alsoTime) {
+		return date("M d, Y H:i:s",$timestamp);
+	}
+	return date("M d, Y",$timestamp);
+}
+
 function getSQLFormatDate($timestamp=null) {
 	if (is_null($timestamp)) {
 		$timestamp=time();
@@ -1418,15 +1449,20 @@ function getTimestampFromSQL($sql_date) {
 	return false;
 }
 
-function getTimestampFromDate($date) {
-	preg_match("/^(\d{1,2})\.(\d{1,2})\.(\d{2,4})/",$date,$result); // JJJJ-MM-TT
-	if ($result) {
-		return getTimestamp($result[1],$result[2],$result[3]);
+function getTimestampFromDate($date) {    //Khoi's note: mainly used by import function
+	if (preg_match("/^(\d{1,2})\.(\d{1,2})\.(\d{2,4})/",$date,$result)) {   // JJJJ-MM-TT: German date style
+		if ($result) {
+			return getTimestamp($result[1],$result[2],$result[3]);
+		}	
+	} elseif (preg_match("/^(\d{1,2})[\/-](\d{1,2})[\/-](\d{2,4})/",$date,$result)) { // mm-dd-yyyy, American date
+		if ($result) {
+			return getTimestamp($result[2],$result[1],$result[3]);    // for American date
+		}
 	}
 	return false;
 }
 
-function fixDate($str,$alsoTime=false) {
+function fixDate($str,$alsoTime=false) {   // Khoi's note: seems to be for search function by date
 	global $lang;
 	if ($alsoTime) {
 		$invalid=invalidSQLDateTime;
@@ -1445,24 +1481,50 @@ function fixDate($str,$alsoTime=false) {
 			return $str;
 		}
 	}
-	preg_match("/^(\d{1,2}).(\d{1,2}).(\d{2,4})\$/",$str,$result); // TT-MM-JJJJ
+	// preg_match("/^(\d{1,2}).(\d{1,2}).(\d{2,4})\$/",$str,$result); // TT-MM-JJJJ
+	preg_match("/^(\d{1,2})\.(\d{1,2})\.(\d{2,4})\$/",$str,$result); // TT-MM-JJJJ
 	if ($result) {
 		fillZero($result[1]);
 		fillZero($result[2]);
 		return fixYear($result[3])."-".$result[2]."-".$result[1];
+        // return fixYear($result[2])."-".$result[3]."-".$result[1];
+	}
+	preg_match("/^(\d{1,2})[\/-](\d{1,2})[\/-](\d{2,4})\$/",$str,$result); // Khoi's note: MM-DD-YYYY, MM/DD/YYYY, MM/DD/YY
+	if ($result) {
+		fillZero($result[1]);
+		fillZero($result[2]);
+		// return fixYear($result[3])."-".$result[2]."-".$result[1];
+        return fixYear($result[3])."-".$result[1]."-".$result[2];
 	}
 	if ($alsoTime) {
-		preg_match("/^(\d{1,2}).(\d{1,2}).(\d{2,4}) (\d{1,2}).(\d{2})\$/",$str,$result); // TT-MM-JJJJ hh:mm
-		if ($result) {
-			$result[6]="00";
+		// Khoi's note: for German style
+		if (preg_match("/^(\d{1,2})\.(\d{1,2})\.(\d{2,4}) (\d{1,2}).(\d{2})\$/",$str,$result)) { // TT-MM-JJJJ hh:mm
+			if ($result) {
+				$result[6]="00";
+			}
+			else {
+				preg_match("/^(\d{1,2})\.(\d{1,2})\.(\d{2,4}) (\d{1,2}).(\d{2}).(\d{2})\$/",$str,$result); // TT-MM-JJJJ hh:mm:ss
+			}
+			if ($result) {
+				fillZero($result[1]);
+				fillZero($result[2]);
+				return fixYear($result[3])."-".$result[2]."-".$result[1]." ".$result[4].":".$result[5].":".$result[6];
+			}
 		}
-		else {
-			preg_match("/^(\d{1,2}).(\d{1,2}).(\d{2,4}) (\d{1,2}).(\d{2}).(\d{2})\$/",$str,$result); // TT-MM-JJJJ hh:mm:ss
-		}
-		if ($result) {
-			fillZero($result[1]);
-			fillZero($result[2]);
-			return fixYear($result[3])."-".$result[2]."-".$result[1]." ".$result[4].":".$result[5].":".$result[6];
+		// Khoi's note: for American style
+		elseif (preg_match("/^(\d{1,2})[\/-](\d{1,2})[\/-](\d{2,4}) (\d{1,2}).(\d{2})\$/",$str,$result)) { // Khoi's note: MM-DD-YYYY, MM/DD/YYYY, MM/DD/YY hh:mm
+			if ($result) {
+				$result[6]="00";
+			}
+			else {
+				preg_match("/^(\d{1,2})[\/-](\d{1,2})[\/-](\d{2,4}) (\d{1,2}).(\d{2}).(\d{2})\$/",$str,$result); // Khoi's note: MM-DD-YYYY, MM/DD/YYYY, MM/DD/YY hh:mm:ss
+			}
+			if ($result) {
+				fillZero($result[1]);
+				fillZero($result[2]);
+				return fixYear($result[3])."-".$result[1]."-".$result[2]." ".$result[4].":".$result[5].":".$result[6];
+				// return fixYear($result[2])."-".$result[3]."-".$result[1]." ".$result[4].":".$result[5].":".$result[6];
+			}
 		}
 	}
 	return $invalid;


### PR DESCRIPTION
What:
1. This commit adds a few extra date format (mm/dd/yyyy as well as
yyyy-mm-dd for no confusion regardless of wherever in the world you are
using OE).
2. This commits also add function so that the open_date and
order_date when import can be recognize in any format (dd.mm.yyyy or
mm/dd/yyyy or mm-dd-yyyy).
3. This also help with date search. Now user can type date in search box
in any format (dd.mm.yy or mm/dd/yy)

Why: with OE is being used more and more all over the world, this
function will help users not from Germanny to find it even more useful