### PR TITLE
Fixes for mariadb 10.6

### DIFF
--- a/lib_constants_tables_analytics.php
+++ b/lib_constants_tables_analytics.php
@@ -36,7 +36,7 @@ $tables["analytical_data_image"]=array(
 	"versioning" => true, "recordCreationChange" => true, 
 	
 	"fields" => array(
-		"analytical_data_id" => array("type" => "INT UNSIGNED", "search" => "auto", "fk" => "analytical_data_id", ),
+		"analytical_data_id" => array("type" => "INT UNSIGNED", "search" => "auto", "fk" => "analytical_data", ),
 		"project_id" => array("type" => "INT UNSIGNED", "search" => "auto", "fk" => "project", ),
 		"reaction_id" => array("type" => "INT UNSIGNED", "search" => "auto", "fk" => "reaction", ),
 		"image_no" => array("type" => "INT", "search" => "auto", "index" => true, ), // 1,2,...
@@ -77,7 +77,7 @@ $tables["analytical_data"]=array(
 		"analytical_data_raw_blob" => array("type" => "MEDIUMBLOB"), // rohdaten, zip
 		"analytical_data_blob" => array("type" => "MEDIUMBLOB", "flags" => FIELD_IMAGE, ), // bearbeitete daten, zip
 		"measured_by" => array("type" => "TINYTEXT", "search" => "auto"), 
-		"solvent" => array("type" => "INT UNSIGNED", "search" => "auto", "fk" => "solvent", ), // (in particular for NMR), use this perhaps also for solvents used in reations
+		"solvent" => array("type" => "INT UNSIGNED", "search" => "auto"), // (in particular for NMR), use this perhaps also for solvents used in reations
 		"analytical_data_interpretation" => array("type" => "TEXT", "search" => "auto"),
 		"analytical_data_comment" => array("type" => "TEXT", "search" => "auto"),
 		"analytical_data_properties_blob" => array("type" => "MEDIUMBLOB"),

--- a/lib_root_funcs.php
+++ b/lib_root_funcs.php
@@ -435,6 +435,12 @@ function createDefaultTableEntries($tabname) {
 			break;
 			}
 		}
+	} elseif ($tabname == "person") {
+	    $sql_query[]="SET SESSION sql_mode='NO_AUTO_VALUE_ON_ZERO';";
+	    $sql_query[]="INSERT INTO ".$tabname." SET ".
+	   	    "person_id=0,".
+	   	    "username=\"root\"".
+	   	    ";";
 	}
 	performQueries($sql_query,$db);
 }

--- a/lib_root_funcs.php
+++ b/lib_root_funcs.php
@@ -285,15 +285,11 @@ function getColumn($name,$data) { // Array
 	if (isset($data["default"])) {
 		$dataType.=" DEFAULT ".$data["default"];
 	}
-	
+
 	if (!empty($data["collate"])) {
 		$dataType.=" COLLATE ".$data["collate"];
 	}
-	
-	if (!empty($data["fk"])) {
-		$dataType.=" REFERENCES ".$data["fk"]."(".getShortPrimary($data["fk"]).")";
-	}
-	
+
 	$field_def=array(
 		"name" => $name, 
 		"def" => $dataType, 
@@ -474,6 +470,36 @@ function createViews() {
 	}
 }
 
+function createTableConstraint($tabname)
+{
+    global $db,$tables;
+    $constraint_query = array();
+
+    $tabdata=& $tables[$tabname];
+    $constraint = 1;
+
+    if (is_array($tabdata["fields"])) foreach ($tabdata["fields"] as $name => $data) {
+        if (!empty($data["fk"])) {
+            $constraint_query [] =
+                "ALTER TABLE ".$tabname.
+                " ADD CONSTRAINT ".$tabname."_fk".$constraint.
+                " FOREIGN KEY (".$name.")".
+                " REFERENCES ".$data["fk"]."(".getShortPrimary($data["fk"]).")".
+                ";";
+            $constraint++;
+        }
+    }
+    performQueries($constraint_query, $db);
+}
+
+function createConstraints() {
+    global $tables;
+    $tabnames=array_keys($tables);
+    foreach ($tabnames as $tabname) {
+        createTableConstraint($tabname);
+    }
+}
+
 function containsInvalidChars($text) {
 	if (preg_match("/^[a-zA-Z0-9_]+\$/",$text)) {
 		return false;
@@ -516,6 +542,7 @@ function setupInitTables($db_name) { // requires root
 		// Tabellen erstellen
 		createTables();
 		createViews();
+		createConstraints();
 		// Views erstellen (rely on tables)
 		setGVar("Version",currentVersion);
 		$version=currentVersion;


### PR DESCRIPTION
Hello, I've had problems getting it running at all on Alpine 3.15 (MariaDB 10.6.4, PHP 7.4).  It seems to enforce all foreign keys. As such, you can only refer to existing tables. In order to make it simpler, foreign key constraints are usually added after all tables have been created, which is what I changed. 
The remaining changes follow, because some column names were created incorrectly.
Furthermore the root/admin user with `person_id=0` which is called on startup in `lib_server_cache.php:writeCache`